### PR TITLE
Enable sync token storage for the nio client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.cfg
+*.db
 matrix-bot.account
 
 zgame-savegames

--- a/config.cfg.sample
+++ b/config.cfg.sample
@@ -2,7 +2,10 @@
 base_url = https://matrix.somewhere.org
 user_id = @bot:matrix.somewhere.org
 password = P4SSW0RD
-device_id = bot-config
+device_name = MatrixBot
+device_id = 0
+store_path = data/
+debug = False
 
 [giphy]
 api_key = GIPHY_API_KEY
@@ -10,6 +13,9 @@ api_key = GIPHY_API_KEY
 [google]
 api_key = GOOGLE_API_KEY
 cx = GOOGLE_CX
+
+[tenor]
+api_key = TENOR_API_KEY
 
 [users]
 female =


### PR DESCRIPTION
Sync tokens allow clients to inform servers of when they last synced so that only newer (unprocessed) events are delivered. This replaces the current system of examining timestamps for received events and assuming that messages should be discarded if older than 5 seconds.

There are a few changes/unknowns that may require extra work from you to get up and running... sorry!

**Device IDs & message replay**
matrix-nio uses the device ID to store the sync token locally. Make sure it's set in your config and be prepared for the first connect to possibly replay the bot's responses to older messages. I couldn't easily test this so I'm not sure how far back the messages will go.

A related side effect of using sync tokens is that bots can now respond to messages sent while they were offline! This could be annoying if messages are very old, but it's also quite helpful if the bot has a slow/unstable connection to the server. Maybe a timestamp check still makes sense here, but increased to (e.g.) a minute instead of 5 seconds?

**Data folder**
The token DB lives inside the `store_path` folder defined in the config. You'll need to create it before running the bot. 

**OLM**
If things are broken it's probably OLM's fault. I ended up building the library and python bindings [from source](https://gitlab.matrix.org/matrix-org/olm) and carefully shuffling the files around my system until things started working. Good luck! 
(Also, I think there's an undocumented dependency on [peewee](https://pypi.org/project/peewee/) within matrix-nio, but maybe I just broke something.)
